### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,24 +7,24 @@
 #######################################
 
 YASM	KEYWORD1
-BTN     KEYWORD1
+BTN	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-next	    KEYWORD2
-run 	    KEYWORD2
-stop	    KEYWORD2
-resume	    KEYWORD2
+next	KEYWORD2
+run	KEYWORD2
+stop	KEYWORD2
+resume	KEYWORD2
 timeOnState	KEYWORD2
-elapsed	    KEYWORD2
+elapsed	KEYWORD2
 periodic	KEYWORD2
 isFirstRun	KEYWORD2
 runCount	KEYWORD2
 isInState	KEYWORD2
-state       KEYWORD2
-update      KEYWORD2
+state	KEYWORD2
+update	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords